### PR TITLE
More Marshalers #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- More Marshalers: `only`, `except`, `filter`, `dates`, `objectVars`, `doctrineReference`, `typeCast` #1
+
 ## 0.2.1
 
 - Added `on` func

--- a/README.md
+++ b/README.md
@@ -122,6 +122,30 @@ transforms the keys of the data into a new key
 
 renames key fields into a new name
 
+### only(array $fields)
+
+It only includes the given fields. Everything else is filtered out.
+
+### except(array $fields)
+
+It includes all except the given fields. Everything else is kept.
+
+### filter(callable $filter)
+
+Filters the collection via the filter func which has the signature `$filter($value, $key): bool`
+
+### dates($format = 'r')
+
+Formats all instances of `DateTimeInterface` with the given format specifier.
+
+### objectVars()
+
+Converts the properties of an object into an array. This is just an alias of `get_object_vars`.
+
+### typeCast(array $fields, $type)
+
+Type casts the given fields into a specific type.
+
 ### pipe($marshalers)
 
 Creates a marshaler that pipes the result of one marshaler into the next marshaler

--- a/src/util.php
+++ b/src/util.php
@@ -15,7 +15,7 @@ function reduce($data, $map, $start = null) {
 
 function map($data, $map) {
     return reduce($data, function($acc, $v, $k) use ($map) {
-        $acc[] = $map($v);
+        $acc[$k] = $map($v, $k);
         return $acc;
     }, []);
 }

--- a/test/marshalers.php
+++ b/test/marshalers.php
@@ -2,6 +2,52 @@
 
 use Krak\Marshal as m;
 
+describe('#only', function() {
+    it('only allows the given fields', function() {
+        $data = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+        $m = m\only(['a']);
+        assert($m($data) == ['a' => 1]);
+    });
+});
+describe('#except', function() {
+    it('allows all except the given fields', function() {
+        $data = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+        $m = m\except(['b', 'c']);
+        assert($m($data) == ['a' => 1]);
+    });
+});
+describe('#objectVars', function() {
+    it('converts an object into an array', function() {
+        $data = (object) ['a' => 1];
+        $m = m\objectVars();
+        assert($m($data) == ['a' => 1]);
+    });
+});
+describe('#dates', function() {
+    it('formats any dates', function() {
+        $data = [new \DateTime()];
+        $data[0]->format('r');
+        $m = m\dates();
+        assert($m($data)[0] == $data[0]->format('r'));
+    });
+});
+describe('#typeCast', function() {
+    it('type casts certain fields into a type', function() {
+        $data = ['a' => '0', 'b' => 1];
+        $m = m\typeCast(['a', 'b'], 'bool');
+        $data = $m($data);
+        assert($data['a'] === false && $data['b'] === true);
+    });
+});
+
 describe('#mock', function() {
     it('returns the same data always', function() {
         $m = m\mock('abc');


### PR DESCRIPTION
- Added several more marshalers:
  `only`, `except`, `filter`, `dates`, `objectVars`,
  `doctrineReference`, `typeCast`
- Added docs and tests
- map now accepts the key as the second parameter and will preserve
  keys

Signed-off-by: RJ Garcia <rj@bighead.net>